### PR TITLE
docs(README.md): update timeOutUrl default value

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -224,7 +224,7 @@ interface IConfig {
     disablePaste: boolean; // 是否禁用粘贴 默认为false
     ignore?: (string|RegExp)[] | null | (()=>boolean); // 某些情况忽略禁用
     disableIframeParents?: boolean; // iframe中是否禁用所有父窗口
-    timeOutUrl?: string; // 关闭页面超时跳转的url;
+    timeOutUrl?: string; // 关闭页面超时跳转的url，默认为https://theajack.github.io/disable-devtool/404.html?h=${encodeURIComponent(location.host)}
     rewriteHTML: string; // 检测到打开之后重写页面
 }
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ declare interface IConfig {
     disablePaste: boolean; // Whether to disable paste, default is false
     ignore?: (string| RegExp)[] | null | (()=>boolean); // Some cases ignore the disablement
     disableIframeParents?: boolean; // Whether all parent windows are disabled in the iframe
-    timeOutUrl?: string; // Turn off URLs that page timeouts forward towards
+    timeOutUrl?: string; // Turn off URLs that page timeouts forward towards, the default is https://theajack.github.io/disable-devtool/404.html?h=${encodeURIComponent(location.host)}
     rewriteHTML?: string; // Detecting the rewriting page after opening
 }
 


### PR DESCRIPTION
修改下README.md 中timeOutUrl描述，方便直接定位关闭页面失败且未配置timeOutUrl时的默认跳转地址