### PR TITLE
fix: 修复 isMobile 函数将触摸屏 PC 误判为移动设备的问题

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -130,9 +130,11 @@ function isMobileByUa () {
 }
 
 function isMobile () {
-  const {platform, maxTouchPoints} = navigator;
-  if (typeof maxTouchPoints === 'number') {
-    return maxTouchPoints > 1;
+  // @ts-ignore
+  const {platform, maxTouchPoints, userAgentData} = navigator;
+  //  userAgentData 是较新的 API，直接提供 mobile 属性
+  if (userAgentData?.mobile) {
+    return userAgentData.mobile;
   }
   if (typeof platform === 'string') {
     const v = platform.toLowerCase();


### PR DESCRIPTION
- 移除 maxTouchPoints 的优先判断，因为它无法区分触摸屏 PC 和移动设备
- 调整判断顺序，先通过 platform 判断桌面系统
- Windows/Mac 触摸屏设备不再被误判为移动设备