### PR TITLE
fix: performance detector broken by third-party console overrides

### DIFF
--- a/src/detector/sub-detector/performance.ts
+++ b/src/detector/sub-detector/performance.ts
@@ -6,7 +6,7 @@
 
 import {Detector} from '../detector';
 import {DetectorType} from 'src/utils/enum';
-import {clearLog, log, table} from 'src/utils/log';
+import {clearLog, table} from 'src/utils/log';
 import {calculateTime, IS, createLargeObjectArray} from 'src/utils/util';
 
 export default class extends Detector {
@@ -17,7 +17,7 @@ export default class extends Detector {
   constructor () {
     super({
       type: DetectorType.Performance,
-      enabled: IS.chrome || !IS.mobile
+      enabled: IS.chrome || !IS.mobile,
     });
   }
 
@@ -28,8 +28,8 @@ export default class extends Detector {
 
   detect () {
     const tablePrintTime = calculateTime(() => {table(this.largeObjectArray);});
-    const logPrintTime = calculateTime(() => {log(this.largeObjectArray);});
-    this.maxPrintTime = Math.max(this.maxPrintTime, logPrintTime);
+    const jsBaselineTime = calculateTime(() => {JSON.stringify(this.largeObjectArray);});
+    this.maxPrintTime = Math.max(this.maxPrintTime, jsBaselineTime);
 
     clearLog();
 


### PR DESCRIPTION
## Summary
The performance detector's baseline used a cached `console.log` captured at init. When SDKs like Sentry wrap `console.log` before that, every baseline tick includes their breadcrumb/serialization overhead, so `maxPrintTime` inflates and the `tablePrintTime > maxPrintTime * 10` check never fires—even with DevTools open.

## Fix
Measure the baseline with `JSON.stringify` on the same large object array instead of `console.log`, so the baseline stays independent of console wrappers and DevTools rendering.