### PR TITLE
fix: use performance.now() instead of Date.getTime() for timing

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,7 +1,9 @@
 
 
 export function now () {
-  return new Date().getTime();
+  return (typeof performance !== 'undefined' && performance.now)
+    ? performance.now()
+    : new Date().getTime();
 }
 
 export function calculateTime (func: Function) {


### PR DESCRIPTION
## Summary
`calculateTime()` used `Date.getTime()`, which test frameworks, fake timers, and some APM tools commonly patch. A constant override collapses every measurement to 0, so the `=== 0` guard in `detect()` bails out every tick and the detector is silently disabled.

## Fix
Prefer `performance.now()` (with a `Date.getTime()` fallback). It uses the browser's monotonic clock, is harder to stub into a stable constant, and avoids the 1ms floor that made those `=== 0` guards necessary.